### PR TITLE
Fix docs on button row helper

### DIFF
--- a/src/utils/menu/abstract.py
+++ b/src/utils/menu/abstract.py
@@ -124,7 +124,7 @@ class MenuAbstract(abc.ABC):
 
         :param data: Данные для преобразования в кнопки.
         :param postfix: Постфикс для добавления в конец пути.
-        :return: Кнопки из данных.
+        :return: None
         """
         row_buttons = []
 


### PR DESCRIPTION
## Summary
- clarify `add_rows_from_data` return type in `MenuAbstract`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a0d4bb5c8323913219ee55e9ff94