### PR TITLE
feat: add markdown text splitter

### DIFF
--- a/src/plugins/bot/utils/text_splitter.py
+++ b/src/plugins/bot/utils/text_splitter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List
+
+import settings
+from plugins.user.utils.text_length import tg_len
+
+
+def _split_long_text(text: str, limit: int) -> List[str]:
+    """Split long text into chunks that fit within Telegram limits."""
+    segments: List[str] = []
+    current = ""
+    for line in text.split("\n"):
+        candidate = line if not current else f"{current}\n{line}"
+        if tg_len(candidate) <= limit:
+            current = candidate
+            continue
+        if current:
+            segments.append(current)
+        if tg_len(line) <= limit:
+            current = line
+            continue
+        chunk = ""
+        for char in line:
+            candidate = chunk + char
+            if tg_len(candidate) <= limit:
+                chunk = candidate
+            else:
+                segments.append(chunk)
+                chunk = char
+        current = chunk
+    if current:
+        segments.append(current)
+    return segments
+
+
+def split_markdown(text: str) -> List[str]:
+    """Split markdown text into Telegram sized pages preserving paragraphs."""
+    if not text:
+        return []
+    limit = settings.TELEGRAM_MAX_TEXT_LENGTH
+    pages: List[str] = []
+    page = ""
+    for paragraph in text.split("\n\n"):
+        if tg_len(paragraph) > limit:
+            if page:
+                pages.append(page)
+                page = ""
+            pages.extend(_split_long_text(paragraph, limit))
+            continue
+        candidate = paragraph if not page else f"{page}\n\n{paragraph}"
+        if tg_len(candidate) <= limit:
+            page = candidate
+        else:
+            if page:
+                pages.append(page)
+            page = paragraph
+    if page:
+        pages.append(page)
+    return pages

--- a/tests/unit/plugins/bot/utils/test_text_splitter.py
+++ b/tests/unit/plugins/bot/utils/test_text_splitter.py
@@ -1,0 +1,40 @@
+import src.plugins.bot.utils.text_splitter as text_splitter
+
+
+def test_split_markdown_preserves_paragraphs(monkeypatch):
+    monkeypatch.setattr(
+        text_splitter.settings, "TELEGRAM_MAX_TEXT_LENGTH", 11
+    )
+    text = "aaaaa\n\nbbbbb"
+    assert text_splitter.split_markdown(text) == ["aaaaa", "bbbbb"]
+
+
+def test_split_markdown_aggregates_paragraphs(monkeypatch):
+    monkeypatch.setattr(
+        text_splitter.settings, "TELEGRAM_MAX_TEXT_LENGTH", 17
+    )
+    text = "11111\n\n22222\n\n33333"
+    assert text_splitter.split_markdown(text) == [
+        "11111\n\n22222",
+        "33333",
+    ]
+
+
+def test_split_markdown_splits_long_paragraph(monkeypatch):
+    monkeypatch.setattr(
+        text_splitter.settings, "TELEGRAM_MAX_TEXT_LENGTH", 10
+    )
+    text = "a" * 25
+    assert text_splitter.split_markdown(text) == [
+        "a" * 10,
+        "a" * 10,
+        "a" * 5,
+    ]
+
+
+def test_split_markdown_uses_tg_len(monkeypatch):
+    monkeypatch.setattr(
+        text_splitter.settings, "TELEGRAM_MAX_TEXT_LENGTH", 3
+    )
+    text = "🙂a🙂"
+    assert text_splitter.split_markdown(text) == ["🙂a", "🙂"]


### PR DESCRIPTION
## Summary
- add utility to split markdown into Telegram-sized pages
- add unit tests for markdown splitter

## Testing
- `pre-commit run --files tests/unit/plugins/bot/utils/test_text_splitter.py` *(fails: HTTP 403 when fetching hook)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ba7ccb848323a3464633dbd3b9a7