### PR TITLE
Add read button to main menu

### DIFF
--- a/src/plugins/bot/buttons.py
+++ b/src/plugins/bot/buttons.py
@@ -10,6 +10,7 @@ SOURCES_BTN = ButtonData(title="📚 Источники", path="s")
 FILTERS_BTN = ButtonData(title="🪤 Фильтры", path="ft")
 CLEANUPS_BTN = ButtonData(title="🧹 Очистка", path="cl")
 ALERT_RULES_BTN = ButtonData(title="🔔 Уведомления", path="r")
+READ_BTN = ButtonData(title="📖 Читать", path="rd")
 MESSAGES_HISTORIES_BTN = ButtonData(title="📖 Сообщения", path="mh")
 STATISTICS_BTN = ButtonData(title="📊 Статистика", path="stat")
 CHECK_POST_BTN = ButtonData(title="🚧 Проверить пост", path=":check_post")
@@ -108,6 +109,12 @@ class ButtonAdder(ButtonAdderBase):
     def options(self, back_step: int = 0):
         self._add_row_button(
             button=OPTIONS_BTN,
+            back_step=back_step,
+        )
+
+    def read(self, back_step: int = 0):
+        self._add_row_button(
+            button=READ_BTN,
             back_step=back_step,
         )
 

--- a/src/plugins/bot/handlers/main.py
+++ b/src/plugins/bot/handlers/main.py
@@ -33,6 +33,7 @@ async def main_menu_by_button(menu: Menu):
 
 def _set_main_menu_buttons(menu: Menu):
     if menu.is_admin_user():
+        menu.add_button.read()
         menu.add_button.categories()
         menu.add_button.sources()
         menu.add_button.alert_rules(user_id=menu.user.id)


### PR DESCRIPTION
## Summary
- add `read` button definition and handler wrapper
- show `read` button in main menu for admin users only

## Testing
- `pytest`
- `pre-commit run --files src/plugins/bot/buttons.py src/plugins/bot/handlers/main.py` *(fails: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896f56c9edc8323a439302c0ce4c57b